### PR TITLE
Fix DNS latency on https.

### DIFF
--- a/blip.js
+++ b/blip.js
@@ -193,8 +193,8 @@ function startBlips() {
       let url = blip.url;
       if (!blip.url) {
         // Desired URL format:
-        //   http://x<rand>.<ndt_site>.blipdns.apenwarr.ca:<port>
-        url = 'http://' +
+        //   https://x<rand>.<ndt_site>.blipdns.apenwarr.ca:<port>
+        url = 'https://' +
                 'x' + Math.floor(Math.random()*1e9) +
                 '.' + dnsName +
                 '.blipdns.apenwarr.ca';


### PR DESCRIPTION
We need to try to connect to a new https URL instead of http or Chrome blocks the request locally.