### PR TITLE
Remove start script as it's no longer useful.

### DIFF
--- a/start
+++ b/start
@@ -1,3 +1,0 @@
-#!/bin/sh
-exec ../google_appengine/dev_appserver.py \
-	--host 0.0.0.0 --port 1111 --admin_port 1114 .


### PR DESCRIPTION
The one piece running under appengine (mindelay) was deleted, so there's no longer any point having a script to run it locally.

You can now test locally (potentially modulo ssl issues) by just using index.html directly.